### PR TITLE
feat: add `guidepup/setup-action` to ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,8 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Setup Environment
+        uses: guidepup/setup-action@0.1.3
       - name: npm ci and npm run ci
         run: |
           npm ci


### PR DESCRIPTION
Noticed that you had tried adding the tests to your workflow following the release of the macos virtual-environment changes but they're currently failing.

I've created <https://github.com/guidepup/setup/> and subsequently <https://github.com/guidepup/setup-action/> to cover the gap for env setup in GitHub actions for some of my repos, so thought would share 🙃 

With this change (which automates config of some TCC.db entries etc.) your tests now pass in CI - see <https://github.com/guidepup/web-test-runner-voiceover/runs/5029221721?check_suite_focus=true>

---

Feel free to ignore / dismiss!